### PR TITLE
Don't panic if `readdrivestat` returns negative value

### DIFF
--- a/iostat_darwin.go
+++ b/iostat_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package iostat
@@ -8,18 +9,23 @@ package iostat
 // #include "iostat_darwin.h"
 import "C"
 import (
+	"fmt"
 	"time"
 )
 
 // ReadDriveStats returns statictics of each of the drives.
 func ReadDriveStats() ([]*DriveStats, error) {
 	var buf [C.NDRIVE]C.DriveStats
-	n, err := C.readdrivestat(&buf[0], C.int(len(buf)))
+	_n, err := C.readdrivestat(&buf[0], C.int(len(buf)))
 	if err != nil {
 		return nil, err
 	}
+	n := int(_n)
+	if n < 0 {
+		return nil, fmt.Errorf("native function call (`readdrivestat`) failed with an error code: %d", n)
+	}
 	stats := make([]*DriveStats, n)
-	for i := 0; i < int(n); i++ {
+	for i := 0; i < n; i++ {
 		stats[i] = &DriveStats{
 			Name:           C.GoString(&buf[i].name[0]),
 			Size:           int64(buf[i].size),

--- a/iostat_darwin.go
+++ b/iostat_darwin.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-// ReadDriveStats returns statictics of each of the drives.
+// ReadDriveStats returns statistics of each of the drives.
 func ReadDriveStats() ([]*DriveStats, error) {
 	var buf [C.NDRIVE]C.DriveStats
 	_n, err := C.readdrivestat(&buf[0], C.int(len(buf)))

--- a/iostat_linux.go
+++ b/iostat_linux.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 package iostat
@@ -6,7 +7,7 @@ import (
 	"errors"
 )
 
-// ReadDriveStats returns statictics of each of the drives.
+// ReadDriveStats returns statistics of each of the drives.
 func ReadDriveStats() ([]*DriveStats, error) {
 	return nil, errors.New("not implement")
 }


### PR DESCRIPTION
Context: 
We observed several node_exporter panics on a machine which is used to create disk images. 
Machine it could have more than 16 disks or add/remove them while `readdrivestat` is running, so some error in IOKit calls could arise.
That should not lead to a node_exporter failure though.

Here's an example panic log:
```text
panic: runtime error: makeslice: len out of range

goroutine 188748 [running]:
github.com/lufia/iostat.ReadDriveStats(0x40741c0, 0xc0004c7d98, 0xf1b8b744, 0xc000081200, 0xc0004c7da8)
        github.com/lufia/iostat@v1.1.0/iostat_darwin.go:21 +0x86
github.com/prometheus/node_exporter/collector.(*diskstatsCollector).Update(0xc00028c330, 0xc000330b40, 0x4b04200, 0xc00023e1c0)
        github.com/prometheus/node_exporter/collector/diskstats_darwin.go:190 +0x34
github.com/prometheus/node_exporter/collector.execute(0x46d28ac, 0x9, 0x478d080, 0xc00028c330, 0xc000330b40, 0x478ce80, 0xc0001afbc0)
        github.com/prometheus/node_exporter/collector/collector.go:153 +0x84
github.com/prometheus/node_exporter/collector.NodeCollector.Collect.func1(0xc000330b40, 0xc0001afe60, 0x478ce80, 0xc0001afbc0, 0xc0003a13b0, 0x46d28ac, 0x9, 0x478d080, 0xc00028c330)
        github.com/prometheus/node_exporter/collector/collector.go:144 +0x71
created by github.com/prometheus/node_exporter/collector.NodeCollector.Collect
        github.com/prometheus/node_exporter/collector/collector.go:143 +0x13c
```
