### PR TITLE
Prefix C function with lufia_iostat_v1_

### DIFF
--- a/iostat_darwin.c
+++ b/iostat_darwin.c
@@ -15,7 +15,7 @@ static int getdrivestat(io_registry_entry_t d, DriveStats *stat);
 static int fillstat(io_registry_entry_t d, DriveStats *stat);
 
 int
-readdrivestat(DriveStats a[], int n)
+lufia_iostat_v1_readdrivestat(DriveStats a[], int n)
 {
 	mach_port_t port;
 	CFMutableDictionaryRef match;
@@ -134,7 +134,7 @@ fillstat(io_registry_entry_t d, DriveStats *stat)
 }
 
 int
-readcpustat(CPUStats *stats)
+lufia_iostat_v1_readcpustat(CPUStats *stats)
 {
 	mach_port_t port;
 	host_cpu_load_info_data_t load;

--- a/iostat_darwin.go
+++ b/iostat_darwin.go
@@ -16,7 +16,7 @@ import (
 // ReadDriveStats returns statistics of each of the drives.
 func ReadDriveStats() ([]*DriveStats, error) {
 	var buf [C.NDRIVE]C.DriveStats
-	_n, err := C.readdrivestat(&buf[0], C.int(len(buf)))
+	_n, err := C.lufia_iostat_v1_readdrivestat(&buf[0], C.int(len(buf)))
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func ReadDriveStats() ([]*DriveStats, error) {
 // ReadCPUStats returns statistics of CPU usage.
 func ReadCPUStats() (*CPUStats, error) {
 	var cpu C.CPUStats
-	_, err := C.readcpustat(&cpu)
+	_, err := C.lufia_iostat_v1_readcpustat(&cpu)
 	if err != nil {
 		return nil, err
 	}

--- a/iostat_darwin.h
+++ b/iostat_darwin.h
@@ -32,5 +32,5 @@ struct CPUStats {
 	natural_t idle;
 };
 
-extern int readdrivestat(DriveStats a[], int n);
-extern int readcpustat(CPUStats *cpu);
+extern int lufia_iostat_v1_readdrivestat(DriveStats a[], int n);
+extern int lufia_iostat_v1_readcpustat(CPUStats *cpu);


### PR DESCRIPTION
I've a conflict in C function between github.com/lufia/iostat and github.com/shirou/gopsutil: both define the function "readdrivestat". This make impossible to use both library in the same project.

This is the same kind of issue as https://github.com/shirou/gopsutil/issues/1175.

The following program show the issue:
```
package main

import (
        "fmt"
        "github.com/lufia/iostat"
        "github.com/shirou/gopsutil/disk"
)

func main() {
        fmt.Println(disk.IOCounters())
        fmt.Println(iostat.ReadDriveStats())
}
```

```
$ go build main.go
[...]
/opt/homebrew/Cellar/go/1.17.2/libexec/pkg/tool/darwin_arm64/link: running clang failed: exit status 1
duplicate symbol '_readdrivestat' in:
    /var/folders/gq/hqkcdkyd60l1bl2_gtx3mwch0000gn/T/go-link-3768739371/000002.o
    /var/folders/gq/hqkcdkyd60l1bl2_gtx3mwch0000gn/T/go-link-3768739371/000005.o
ld: 1 duplicate symbol for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

