### PR TITLE
Fix macOS 12 deprecation notice

### DIFF
--- a/iostat_darwin.c
+++ b/iostat_darwin.c
@@ -24,7 +24,7 @@ lufia_iostat_v1_readdrivestat(DriveStats a[], int n)
 	kern_return_t status;
 	int na, rv;
 
-	IOMasterPort(bootstrap_port, &port);
+	IOMainPort(bootstrap_port, &port);
 	match = IOServiceMatching("IOMedia");
 	CFDictionaryAddValue(match, CFSTR(kIOMediaWholeKey), kCFBooleanTrue);
 	status = IOServiceGetMatchingServices(port, match, &drives);

--- a/iostat_darwin.h
+++ b/iostat_darwin.h
@@ -34,3 +34,8 @@ struct CPUStats {
 
 extern int lufia_iostat_v1_readdrivestat(DriveStats a[], int n);
 extern int lufia_iostat_v1_readcpustat(CPUStats *cpu);
+
+#if (MAC_OS_X_VERSION_MIN_REQUIRED < 120000)
+	// If deployent target is before monterey, use the old name.
+	#define IOMainPort IOMasterPort
+#endif


### PR DESCRIPTION
Previously compiling on Monterey would print a warning like this:

```
iostat_darwin.c:27:2: warning: 'IOMasterPort' is deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Headers/IOKitLib.h:132:1: note: 'IOMasterPort' has been explicitly marked deprecated here
```

This updates that usage to remove the warning.