### PR TITLE
drop macos-10.15 runner, and upgrade go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ['macos-12', 'macos-11', 'macos-10.15']
-        go: ['1.17.x', '1.16.x']
+        os: ['macos-12', 'macos-11']
+        go: ['1.18.x', '1.17.x']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/